### PR TITLE
Primitive structure for Caddyfile support

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -3,18 +3,130 @@ package certmagicsql
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"time"
 
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/certmagic"
 	_ "github.com/lib/pq"
+	"go.uber.org/zap"
 )
 
 var (
 	_ certmagic.Storage = (*PostgresStorage)(nil)
 )
+
+type PostgresStorage struct {
+	logger *zap.Logger
+
+	QueryTimeout time.Duration `json:"query_timeout,omitempty"`
+	LockTimeout  time.Duration `json:"lock_timeout,omitempty"`
+	Database     *sql.DB       `json:"-"`
+	Host         string        `json:"host"`
+	Port         string        `json:"port"`
+	User         string        `json:"user"`
+	Password     string        `json:"password"`
+	DBname       string        `json:"dbname"`
+	SSLmode      string        `json:"sslmode"`
+}
+
+func init() {
+	caddy.RegisterModule(PostgresStorage{})
+}
+
+func (c *PostgresStorage) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		var value string
+
+		key := d.Val()
+
+		if !d.Args(&value) {
+			continue
+		}
+
+		switch key {
+		case "host":
+			c.Host = value
+		case "port":
+			c.Port = value
+		case "user":
+			c.User = value
+		case "password":
+			c.Password = value
+		case "dbname":
+			c.DBname = value
+		case "sslmode":
+			c.SSLmode = value
+		}
+	}
+
+	return nil
+}
+
+func (c *PostgresStorage) Provision(ctx caddy.Context) error {
+	c.logger = ctx.Logger(c)
+
+	// Load Environment
+	if c.Host == "" {
+		c.Host = os.Getenv("POSTGRES_HOST")
+	}
+	if c.Port == "" {
+		c.Port = os.Getenv("POSTGRES_PORT")
+	}
+	if c.User == "" {
+		c.User = os.Getenv("POSTGRES_USER")
+	}
+	if c.Password == "" {
+		c.Password = os.Getenv("POSTGRES_PASSWORD")
+	}
+	if c.DBname == "" {
+		c.DBname = os.Getenv("POSTGRES_DB")
+	}
+	if c.SSLmode == "" {
+		c.SSLmode = os.Getenv("POSTGRES_SSL")
+	}
+	if c.QueryTimeout == 0 {
+		c.QueryTimeout = time.Second * 3
+	}
+	if c.LockTimeout == 0 {
+		c.LockTimeout = time.Minute
+	}
+
+	return nil
+}
+
+func (PostgresStorage) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.storage.postgres",
+		New: func() caddy.Module {
+			return new(PostgresStorage)
+		},
+	}
+}
+
+func NewStorage(c PostgresStorage) (certmagic.Storage, error) {
+	connStr := "host=%s port=%s user=%s password=%s dbname=%s sslmode=%s"
+	// Set each value dynamically w/ Sprintf
+	connStr = fmt.Sprintf(connStr, c.Host, c.Port, c.User, c.Password, c.DBname, c.SSLmode)
+
+	database, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return nil, err
+	}
+	s := &PostgresStorage{
+		Database:     database,
+		QueryTimeout: c.QueryTimeout,
+		LockTimeout:  c.LockTimeout,
+	}
+	return s, s.ensureTableSetup()
+}
+
+func (c *PostgresStorage) CertMagicStorage() (certmagic.Storage, error) {
+	return NewStorage(*c)
+}
 
 // DB represents the required database API. You can use a *database/sql.DB.
 type DB interface {
@@ -22,39 +134,6 @@ type DB interface {
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-}
-
-// NewStorage creates a new storage instance. The `db` you pass in will likely be a
-// *database/sql.DB. This method will create the required metadata tables if necessary
-// (certmagic_data and certmagic_locks).
-func NewStorage(storage PostgresStorage) (certmagic.Storage, error) {
-	if storage.QueryTimeout == 0 {
-		storage.QueryTimeout = time.Second * 3
-	}
-	if storage.LockTimeout == 0 {
-		storage.LockTimeout = time.Minute
-	}
-	if len(storage.ConnectionString) == 0 {
-		return nil, errors.New("please provide a valid Postgres connection URL")
-	}
-	database, err := sql.Open("postgres", storage.ConnectionString)
-	if err != nil {
-		return nil, err
-	}
-	s := &PostgresStorage{
-		Database:         database,
-		QueryTimeout:     storage.QueryTimeout,
-		LockTimeout:      storage.LockTimeout,
-		ConnectionString: storage.ConnectionString,
-	}
-	return s, s.ensureTableSetup()
-}
-
-type PostgresStorage struct {
-	QueryTimeout     time.Duration `json:"query_timeout,omitempty"`
-	LockTimeout      time.Duration `json:"lock_timeout,omitempty"`
-	Database         *sql.DB       `json:"-"`
-	ConnectionString string        `json:"connection_string,omitempty"`
 }
 
 // Database RDBs this library supports, currently supports Postgres only.

--- a/storage.go
+++ b/storage.go
@@ -30,7 +30,7 @@ type PostgresStorage struct {
 	User         string        `json:"user"`
 	Password     string        `json:"password"`
 	DBname       string        `json:"dbname"`
-	SSLmode      string        `json:"sslmode"`
+	SSLmode      string        `json:"sslmode"` // Valid values for sslmode are: disable, require, verify-ca, verify-full
 }
 
 func init() {
@@ -83,10 +83,10 @@ func (c *PostgresStorage) Provision(ctx caddy.Context) error {
 		c.Password = os.Getenv("POSTGRES_PASSWORD")
 	}
 	if c.DBname == "" {
-		c.DBname = os.Getenv("POSTGRES_DB")
+		c.DBname = os.Getenv("POSTGRES_DBNAME")
 	}
 	if c.SSLmode == "" {
-		c.SSLmode = os.Getenv("POSTGRES_SSL")
+		c.SSLmode = os.Getenv("POSTGRES_SSLMODE")
 	}
 	if c.QueryTimeout == 0 {
 		c.QueryTimeout = time.Second * 3


### PR DESCRIPTION
This enables configuring storage through Caddyfile or Environment variables. Maybe not perfect because I'm no good in Go, but it's working fine. Tested with docker-proxy support and Caddyfile configuration was 100%. A few tweaks and it's good to go.